### PR TITLE
Add DisplayPi fullscreen browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# DisplayPi
+
+This repository contains a small program to display web pages in full screen on Raspberry Pi OS (64‑bit). It starts with `https://www.flightradar24.com` and can rotate through additional URLs if you add them to the script.
+
+## Requirements
+- Raspberry Pi OS 64‑bit with graphical environment
+- Python 3 with `PyQt5` and `PyQtWebEngine`
+
+Install the dependencies:
+```bash
+sudo apt-get update
+sudo apt-get install -y python3-pyqt5 python3-pyqt5.qtwebengine
+```
+
+## Usage
+1. Copy this repository to `/home/pi/DisplayPi` on your Raspberry Pi.
+2. Optionally edit `displaypi.py` and add more URLs in the `URLS` list.
+3. Install the systemd service:
+
+```bash
+sudo cp displaypi.service /etc/systemd/system/displaypi.service
+sudo systemctl daemon-reload
+sudo systemctl enable displaypi.service
+sudo systemctl start displaypi.service
+```
+
+The service will launch the web viewer on boot. To stop it:
+
+```bash
+sudo systemctl stop displaypi.service
+```
+
+## Customization
+- To change the time between URL changes, adjust `INTERVAL_SECONDS` inside `displaypi.py`.
+- Set `INTERVAL_SECONDS` to `0` to disable automatic rotation.

--- a/displaypi.py
+++ b/displaypi.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""DisplayPi - simple full-screen web viewer for Raspberry Pi OS.
+
+Edit the URLS list below to change which websites are shown.
+The application cycles through the URLs in full screen mode.
+"""
+
+import sys
+from PyQt5 import QtCore, QtWidgets, QtWebEngineWidgets
+
+# List of URLs to display
+URLS = [
+    "https://www.flightradar24.com",
+    # Add more URLs here
+]
+
+# Seconds to wait before showing the next URL. Set to 0 to disable rotation.
+INTERVAL_SECONDS = 60
+
+class Browser(QtWidgets.QMainWindow):
+    def __init__(self, urls, interval):
+        super().__init__()
+        self.urls = urls
+        self.index = 0
+        self.interval = interval
+        self.view = QtWebEngineWidgets.QWebEngineView()
+        self.setCentralWidget(self.view)
+        self.load_current_url()
+        self.timer = QtCore.QTimer()
+        self.timer.timeout.connect(self.next_url)
+        if self.interval > 0 and len(self.urls) > 1:
+            self.timer.start(self.interval * 1000)
+        self.showFullScreen()
+
+    def load_current_url(self):
+        self.view.load(QtCore.QUrl(self.urls[self.index]))
+
+    def next_url(self):
+        self.index = (self.index + 1) % len(self.urls)
+        self.load_current_url()
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    browser = Browser(URLS, INTERVAL_SECONDS)
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/displaypi.service
+++ b/displaypi.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=DisplayPi kiosk browser
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+Environment=DISPLAY=:0
+ExecStart=/usr/bin/python3 /home/pi/DisplayPi/displaypi.py
+Restart=on-failure
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
## Summary
- add a python script `displaypi.py` that opens specified URLs in a full-screen PyQt WebEngine browser
- add a systemd service file to run the browser at boot
- include a README with setup instructions

## Testing
- `python3 -m py_compile displaypi.py`


------
https://chatgpt.com/codex/tasks/task_e_68555a72a884832e84aa563527dcc09f