### PR TITLE
Switch to Chromium kiosk launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ This repository contains a small program to display web pages in full screen on 
 
 ## Requirements
 - Raspberry Pi OS 64‑bit with graphical environment
-- Python 3 with `PyQt5` and `PyQtWebEngine`
+- Python 3
+- `chromium-browser`
 
-Install the dependencies:
+Install Chromium if it is not already available:
 ```bash
 sudo apt-get update
-sudo apt-get install -y python3-pyqt5 python3-pyqt5.qtwebengine
+sudo apt-get install -y chromium-browser
 ```
 
 ## Usage
@@ -31,5 +32,6 @@ sudo systemctl stop displaypi.service
 ```
 
 ## Customization
-- To change the time between URL changes, adjust `INTERVAL_SECONDS` inside `displaypi.py`.
+- To change the time between URL changes, edit `INTERVAL_SECONDS` in
+  `displaypi.py`.
 - Set `INTERVAL_SECONDS` to `0` to disable automatic rotation.

--- a/displaypi.py
+++ b/displaypi.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""DisplayPi - simple full-screen web viewer for Raspberry Pi OS.
+"""DisplayPi - simple kiosk launcher using Chromium.
 
-Edit the URLS list below to change which websites are shown.
-The application cycles through the URLs in full screen mode.
+This script opens a list of URLs in fullscreen (kiosk) mode using the
+`chromium-browser` application that comes with Raspberry Pi OS.  The
+browser window is restarted for each URL when rotation is enabled.
 """
 
-import sys
-from PyQt5 import QtCore, QtWidgets, QtWebEngineWidgets
+import subprocess
+import time
+from typing import List
 
 # List of URLs to display
-URLS = [
+URLS: List[str] = [
     "https://www.flightradar24.com",
     # Add more URLs here
 ]
@@ -17,33 +19,39 @@ URLS = [
 # Seconds to wait before showing the next URL. Set to 0 to disable rotation.
 INTERVAL_SECONDS = 60
 
-class Browser(QtWidgets.QMainWindow):
-    def __init__(self, urls, interval):
-        super().__init__()
-        self.urls = urls
-        self.index = 0
-        self.interval = interval
-        self.view = QtWebEngineWidgets.QWebEngineView()
-        self.setCentralWidget(self.view)
-        self.load_current_url()
-        self.timer = QtCore.QTimer()
-        self.timer.timeout.connect(self.next_url)
-        if self.interval > 0 and len(self.urls) > 1:
-            self.timer.start(self.interval * 1000)
-        self.showFullScreen()
-
-    def load_current_url(self):
-        self.view.load(QtCore.QUrl(self.urls[self.index]))
-
-    def next_url(self):
-        self.index = (self.index + 1) % len(self.urls)
-        self.load_current_url()
+CHROMIUM_CMD = [
+    "chromium-browser",
+    "--noerrdialogs",
+    "--kiosk",
+]
 
 
-def main():
-    app = QtWidgets.QApplication(sys.argv)
-    browser = Browser(URLS, INTERVAL_SECONDS)
-    sys.exit(app.exec_())
+def launch_chromium(url: str) -> subprocess.Popen:
+    """Launch Chromium pointing to ``url`` in kiosk mode."""
+    cmd = CHROMIUM_CMD + [url]
+    return subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+
+
+def main() -> None:
+    index = 0
+    proc = launch_chromium(URLS[index])
+
+    try:
+        while True:
+            if INTERVAL_SECONDS <= 0 or len(URLS) == 1:
+                # Wait forever if rotation is disabled.
+                proc.wait()
+                break
+            time.sleep(INTERVAL_SECONDS)
+            proc.terminate()
+            proc.wait()
+            index = (index + 1) % len(URLS)
+            proc = launch_chromium(URLS[index])
+    except KeyboardInterrupt:
+        pass
+    finally:
+        proc.terminate()
+        proc.wait()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace PyQt5-based viewer with simple Chromium launcher in `displaypi.py`
- update README to describe Chromium requirement and usage

## Testing
- `python3 -m py_compile displaypi.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557c83ef5c832e9e09e222c912fab9