### PR TITLE
Update default installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sudo apt-get install -y chromium-browser
 ```
 
 ## Usage
-1. Copy this repository to `/home/pi/DisplayPi` on your Raspberry Pi.
+1. Copy this repository to `/home/diego/DisplayPi` on your Raspberry Pi.
 2. Optionally edit `displaypi.py` and add more URLs in the `URLS` list.
 3. Install the systemd service:
 

--- a/displaypi.service
+++ b/displaypi.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=pi
 Environment=DISPLAY=:0
-ExecStart=/usr/bin/python3 /home/pi/DisplayPi/displaypi.py
+ExecStart=/usr/bin/python3 /home/diego/DisplayPi/displaypi.py
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- document default path `/home/diego/DisplayPi`
- update service file to launch from `/home/diego/DisplayPi`

## Testing
- `python3 -m py_compile displaypi.py`


------
https://chatgpt.com/codex/tasks/task_e_6855895cec3c832e9b991fad314d36b9