### PR TITLE
Modify service to run as diego user

### DIFF
--- a/displaypi.service
+++ b/displaypi.service
@@ -4,8 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
-User=pi
+User=diego
 Environment=DISPLAY=:0
+Environment=XDG_RUNTIME_DIR=/run/user/1000
 ExecStart=/usr/bin/python3 /home/diego/DisplayPi/displaypi.py
 Restart=on-failure
 


### PR DESCRIPTION
## Summary
- adjust systemd service so `User=diego`
- set `XDG_RUNTIME_DIR` for the service

## Testing
- `python3 -m py_compile displaypi.py`

------
https://chatgpt.com/codex/tasks/task_e_68558cd3acb8832eadc93d037cddc401