### PR TITLE
Restore pi user and update Flightradar URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DisplayPi
 
-This repository contains a small program to display web pages in full screen on Raspberry Pi OS (64‑bit). It starts with `https://www.flightradar24.com` and can rotate through additional URLs if you add them to the script.
+This repository contains a small program to display web pages in full screen on Raspberry Pi OS (64‑bit). It starts with `https://www.flightradar24.com/42.74,-1.57/8` and can rotate through additional URLs if you add them to the script.
 
 ## Requirements
 - Raspberry Pi OS 64‑bit with graphical environment
@@ -14,7 +14,7 @@ sudo apt-get install -y chromium-browser
 ```
 
 ## Usage
-1. Copy this repository to `/home/diego/DisplayPi` on your Raspberry Pi.
+1. Copy this repository to `/home/pi/DisplayPi` on your Raspberry Pi.
 2. Optionally edit `displaypi.py` and add more URLs in the `URLS` list.
 3. Install the systemd service:
 

--- a/displaypi.py
+++ b/displaypi.py
@@ -12,7 +12,7 @@ from typing import List
 
 # List of URLs to display
 URLS: List[str] = [
-    "https://www.flightradar24.com",
+    "https://www.flightradar24.com/42.74,-1.57/8",
     # Add more URLs here
 ]
 

--- a/displaypi.service
+++ b/displaypi.service
@@ -4,10 +4,10 @@ After=network.target
 
 [Service]
 Type=simple
-User=diego
+User=pi
 Environment=DISPLAY=:0
 Environment=XDG_RUNTIME_DIR=/run/user/1000
-ExecStart=/usr/bin/python3 /home/diego/DisplayPi/displaypi.py
+ExecStart=/usr/bin/python3 /home/pi/DisplayPi/displaypi.py
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- revert service to run as `pi`
- set Flightradar URL to `42.74,-1.57/8`
- adjust README usage path

## Testing
- `python3 -m py_compile displaypi.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a3dc5398832ea04ba361d68ed903