### PR TITLE
Implement single URL reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ sudo systemctl stop displaypi.service
 - To change the time between URL changes, edit `INTERVAL_SECONDS` in
   `displaypi.py`.
 - Set `INTERVAL_SECONDS` to `0` to disable automatic rotation.
+- Set `RELOAD_SECONDS` to a number greater than `0` to force reload of the
+  single configured URL at that interval. Leave it at `0` to keep the browser
+  open indefinitely when only one URL is present.

--- a/displaypi.py
+++ b/displaypi.py
@@ -16,8 +16,13 @@ URLS: List[str] = [
     # Add more URLs here
 ]
 
-# Seconds to wait before showing the next URL. Set to 0 to disable rotation.
+# Seconds to wait before showing the next URL when multiple URLs are defined.
+# Set to 0 to disable rotation.
 INTERVAL_SECONDS = 60
+
+# Seconds after which the page is reloaded even when only one URL is
+# configured. Set to 0 to disable automatic reload.
+RELOAD_SECONDS = 0
 
 CHROMIUM_CMD = [
     "chromium-browser",
@@ -38,8 +43,18 @@ def main() -> None:
 
     try:
         while True:
-            if INTERVAL_SECONDS <= 0 or len(URLS) == 1:
-                # Wait forever if rotation is disabled.
+            if len(URLS) == 1:
+                if RELOAD_SECONDS > 0:
+                    time.sleep(RELOAD_SECONDS)
+                    proc.terminate()
+                    proc.wait()
+                    proc = launch_chromium(URLS[0])
+                    continue
+                # Wait forever if reload is disabled.
+                proc.wait()
+                break
+            if INTERVAL_SECONDS <= 0:
+                # Rotation disabled when more than one URL is present.
                 proc.wait()
                 break
             time.sleep(INTERVAL_SECONDS)


### PR DESCRIPTION
## Summary
- add `RELOAD_SECONDS` setting to configure page reload when only one URL is present
- reload Chromium when `len(URLS) == 1` and `RELOAD_SECONDS > 0`
- document the new option in the README

## Testing
- `python3 -m py_compile displaypi.py`
- manual execution of the script with a short reload interval

------
https://chatgpt.com/codex/tasks/task_e_6855a777f278832e936dbe4cfa5da812