### PR TITLE
Simplify kiosk script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # DisplayPi
 
-This repository contains a small program to display web pages in full screen on Raspberry Pi OS (64‑bit). It starts with `https://www.flightradar24.com/42.74,-1.57/8` and can rotate through additional URLs if you add them to the script.
+This repository contains a small program to display a web page in full screen on Raspberry Pi OS (64‑bit). By default it opens `https://www.flightradar24.com/42.74,-1.57/8`. The script monitors the page and reloads it only when loading fails.
 
 ## Requirements
 - Raspberry Pi OS 64‑bit with graphical environment
 - Python 3
 - `chromium-browser`
+- `requests` Python package
 
 Install Chromium if it is not already available:
 ```bash
 sudo apt-get update
 sudo apt-get install -y chromium-browser
 ```
+Install the ``requests`` package if it is missing:
+```bash
+pip3 install requests
+```
 
 ## Usage
 1. Copy this repository to `/home/pi/DisplayPi` on your Raspberry Pi.
-2. Optionally edit `displaypi.py` and add more URLs in the `URLS` list.
+2. Optionally edit `displaypi.py` to change the URL.
 3. Install the systemd service:
 
 ```bash
@@ -32,9 +37,6 @@ sudo systemctl stop displaypi.service
 ```
 
 ## Customization
-- To change the time between URL changes, edit `INTERVAL_SECONDS` in
-  `displaypi.py`.
-- Set `INTERVAL_SECONDS` to `0` to disable automatic rotation.
-- Set `RELOAD_SECONDS` to a number greater than `0` to force reload of the
-  single configured URL at that interval. Leave it at `0` to keep the browser
-  open indefinitely when only one URL is present.
+Edit `displaypi.py` if you want to change the URL or tweak how often the script
+checks that the page loaded correctly. Modify `CHECK_SECONDS` to change the
+verification interval.


### PR DESCRIPTION
## Summary
- remove page rotation logic
- update README for the simplified script
- reload only on failure using HTTP checks

## Testing
- `python3 -m py_compile displaypi.py`


------
https://chatgpt.com/codex/tasks/task_e_6855aa6f76c8832ebefdd71ebb2271eb