### PR TITLE
Update default URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DisplayPi
 
-This repository contains a small program to display a web page in full screen on Raspberry Pi OS (64‑bit). By default it opens `https://www.flightradar24.com/42.74,-1.57/8`.
+This repository contains a small program to display a web page in full screen on Raspberry Pi OS (64‑bit). By default it opens `https://www.flightradar24.com/simple/`.
 
 ## Requirements
 - Raspberry Pi OS 64‑bit with graphical environment

--- a/displaypi.py
+++ b/displaypi.py
@@ -8,7 +8,7 @@ This simple script opens a single URL in fullscreen (kiosk) mode using the
 import subprocess
 
 # URL to display
-URL = "https://www.flightradar24.com/42.74,-1.57/8"
+URL = "https://www.flightradar24.com/simple/"
 
 
 CHROMIUM_CMD = [


### PR DESCRIPTION
## Summary
- update the default URL in `displaypi.py`
- document new default URL in the README

## Testing
- `python3 -m py_compile displaypi.py`

------
https://chatgpt.com/codex/tasks/task_e_6855b33ef440832e9efa181d3dfaed3e