### PR TITLE
Add GPIO button controlled URL toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@ This repository contains a small program to display a web page in full screen on
 - Raspberry Pi OS 64‑bit with graphical environment
 - Python 3
 - `chromium-browser`
+- `xdotool`
+- `RPi.GPIO` (usually installed by default on Raspberry Pi OS)
 
 Install Chromium if it is not already available:
 ```bash
 sudo apt-get update
 sudo apt-get install -y chromium-browser
+sudo apt-get install -y xdotool python3-rpi.gpio
 ```
 
 ## Usage
 1. Copy this repository to `/home/pi/DisplayPi` on your Raspberry Pi.
-2. Optionally edit `displaypi.py` to change the URL.
+2. Optionally edit `displaypi.py` to change the URLs.
 3. Install the systemd service:
 
 ```bash
@@ -32,5 +35,6 @@ sudo systemctl stop displaypi.service
 ```
 
 ## Customization
-Edit `displaypi.py` if you want to change the URL or adjust how Chromium is
-launched.
+`displaypi.py` launches Chromium in kiosk mode with two tabs. A push button
+connected to GPIO 27 toggles between them. Edit the script if you need to change
+the URLs or adjust how Chromium is launched.

--- a/displaypi.py
+++ b/displaypi.py
@@ -7,8 +7,14 @@ This simple script opens a single URL in fullscreen (kiosk) mode using the
 
 import subprocess
 
-# URL to display
-URL = "https://www.flightradar24.com/simple/"
+import RPi.GPIO as GPIO
+
+# URLs to display
+URL_1 = "https://www.flightradar24.com/simple/"
+URL_2 = "http://localhost:3000"
+
+# GPIO pin where the button is connected
+BUTTON_PIN = 27
 
 
 CHROMIUM_CMD = [
@@ -18,20 +24,45 @@ CHROMIUM_CMD = [
 ]
 
 
-def launch_chromium(url: str) -> subprocess.Popen:
-    """Launch Chromium pointing to ``url`` in kiosk mode."""
-    cmd = CHROMIUM_CMD + [url]
+def launch_chromium(urls: list[str]) -> subprocess.Popen:
+    """Launch Chromium pointing to ``urls`` in kiosk mode."""
+    cmd = CHROMIUM_CMD + urls
     return subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
 
+def switch_tab(tab_index: int) -> None:
+    """Use ``xdotool`` to switch to ``tab_index`` (1-based)."""
+    subprocess.run(
+        ["xdotool", "key", f"ctrl+{tab_index}"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
 def main() -> None:
-    proc = launch_chromium(URL)
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+    proc = launch_chromium([URL_1, URL_2])
+    current_tab = 1  # Chromium opens the first URL as tab 1
+
+    def handle_button(channel: int) -> None:
+        nonlocal current_tab
+        # Toggle between tab 1 and 2
+        current_tab = 2 if current_tab == 1 else 1
+        switch_tab(current_tab)
+
+    GPIO.add_event_detect(
+        BUTTON_PIN, GPIO.FALLING, callback=handle_button, bouncetime=300
+    )
 
     try:
         proc.wait()
     except KeyboardInterrupt:
         pass
     finally:
+        GPIO.cleanup()
         proc.terminate()
         proc.wait()
 


### PR DESCRIPTION
## Summary
- add GPIO button support to switch between two URLs
- keep Chromium running in kiosk mode with two tabs for smooth switching
- document new dependencies and behaviour in README

## Testing
- `python3 -m py_compile displaypi.py`

------
https://chatgpt.com/codex/tasks/task_e_6855b6851404832ebc45165fd3d417ed