### PR TITLE
Add GPIO cleanup at startup

### DIFF
--- a/displaypi.py
+++ b/displaypi.py
@@ -41,6 +41,8 @@ def switch_tab(tab_index: int) -> None:
 
 
 def main() -> None:
+    # Ensure any previous GPIO configuration is cleared before setting up
+    GPIO.cleanup()
     GPIO.setmode(GPIO.BCM)
     GPIO.setup(BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 


### PR DESCRIPTION
## Summary
- ensure we clean up any leftover GPIO config before setting up

## Testing
- `python3 -m py_compile displaypi.py`

------
https://chatgpt.com/codex/tasks/task_e_6855c194b6cc832e8d62f98124511c1c