### PR TITLE
Handle errors when adding GPIO event detection

### DIFF
--- a/displaypi.py
+++ b/displaypi.py
@@ -55,9 +55,17 @@ def main() -> None:
         current_tab = 2 if current_tab == 1 else 1
         switch_tab(current_tab)
 
-    GPIO.add_event_detect(
-        BUTTON_PIN, GPIO.FALLING, callback=handle_button, bouncetime=300
-    )
+    try:
+        GPIO.add_event_detect(
+            BUTTON_PIN,
+            GPIO.FALLING,
+            callback=handle_button,
+            bouncetime=300,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        # Catch any error so the program can report issues with GPIO setup
+        print(f"Failed to add GPIO event detection: {exc!r}")
+        raise
 
     try:
         proc.wait()


### PR DESCRIPTION
## Summary
- wrap GPIO.add_event_detect in a try/except and log the failure

## Testing
- `python3 -m py_compile displaypi.py`


------
https://chatgpt.com/codex/tasks/task_e_6855d80e9df0832e865cbae92091042b