### PR TITLE
Remove GPIO and simplify DisplayPi setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,16 @@ This repository contains a small program to display a web page in full screen on
 - Raspberry Pi OS 64‑bit with graphical environment
 - Python 3
 - `chromium-browser`
-- `xdotool`
-- `RPi.GPIO` (usually installed by default on Raspberry Pi OS)
 
 Install Chromium if it is not already available:
 ```bash
 sudo apt-get update
 sudo apt-get install -y chromium-browser
-sudo apt-get install -y xdotool python3-rpi.gpio
-```
-
-Install the Python module with pip:
-
-```bash
-pip install -r requirements.txt
 ```
 
 ## Usage
 1. Copy this repository to `/home/pi/DisplayPi` on your Raspberry Pi.
-2. Optionally edit `displaypi.py` to change the URLs.
+2. Optionally edit `displaypi.py` to change the URL.
 3. Install the systemd service:
 
 ```bash
@@ -41,6 +32,5 @@ sudo systemctl stop displaypi.service
 ```
 
 ## Customization
-`displaypi.py` launches Chromium in kiosk mode with two tabs. A push button
-connected to GPIO 27 toggles between them. Edit the script if you need to change
-the URLs or adjust how Chromium is launched.
+Edit `displaypi.py` if you want to change the URL or adjust how Chromium is
+launched.

--- a/displaypi.py
+++ b/displaypi.py
@@ -7,15 +7,8 @@ This simple script opens a single URL in fullscreen (kiosk) mode using the
 
 import subprocess
 
-import RPi.GPIO as GPIO
-
-# URLs to display
-URL_1 = "https://www.flightradar24.com/simple/"
-URL_2 = "http://localhost:3000"
-
-# GPIO pin where the button is connected
-BUTTON_PIN = 27
-
+# URL to display
+URL = "https://www.flightradar24.com/simple/"
 
 CHROMIUM_CMD = [
     "chromium-browser",
@@ -24,55 +17,20 @@ CHROMIUM_CMD = [
 ]
 
 
-def launch_chromium(urls: list[str]) -> subprocess.Popen:
-    """Launch Chromium pointing to ``urls`` in kiosk mode."""
-    cmd = CHROMIUM_CMD + urls
+def launch_chromium(url: str) -> subprocess.Popen:
+    """Launch Chromium pointing to ``url`` in kiosk mode."""
+    cmd = CHROMIUM_CMD + [url]
     return subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
 
-def switch_tab(tab_index: int) -> None:
-    """Use ``xdotool`` to switch to ``tab_index`` (1-based)."""
-    subprocess.run(
-        ["xdotool", "key", f"ctrl+{tab_index}"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
-
-
 def main() -> None:
-    # Ensure any previous GPIO configuration is cleared before setting up
-    GPIO.cleanup()
-    GPIO.setmode(GPIO.BCM)
-    GPIO.setup(BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-
-    proc = launch_chromium([URL_1, URL_2])
-    current_tab = 1  # Chromium opens the first URL as tab 1
-
-    def handle_button(channel: int) -> None:
-        nonlocal current_tab
-        # Toggle between tab 1 and 2
-        current_tab = 2 if current_tab == 1 else 1
-        switch_tab(current_tab)
-
-    try:
-        GPIO.add_event_detect(
-            BUTTON_PIN,
-            GPIO.FALLING,
-            callback=handle_button,
-            bouncetime=300,
-        )
-    except Exception as exc:  # pylint: disable=broad-except
-        # Catch any error so the program can report issues with GPIO setup
-        print(f"Failed to add GPIO event detection: {exc!r}")
-        raise
+    proc = launch_chromium(URL)
 
     try:
         proc.wait()
     except KeyboardInterrupt:
         pass
     finally:
-        GPIO.cleanup()
         proc.terminate()
         proc.wait()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-RPi.GPIO


### PR DESCRIPTION
## Summary
- drop GPIO handling from `displaypi.py`
- remove related dependencies from README
- remove package requirement file

## Testing
- `python3 -m py_compile displaypi.py`

------
https://chatgpt.com/codex/tasks/task_e_685686eea950832e978f255581262c99