### PR TITLE
Add URL selection via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DisplayPi
 
-This repository contains a small program to display a web page in full screen on Raspberry Pi OS (64‑bit). By default it opens `https://www.flightradar24.com/simple/`.
+This repository contains a small program to display a web page in full screen on Raspberry Pi OS (64‑bit). By default it opens `https://www.flightradar24.com/simple/`. It can also display a locally hosted page at `http://localhost:3000`.
 
 ## Requirements
 - Raspberry Pi OS 64‑bit with graphical environment
@@ -15,7 +15,7 @@ sudo apt-get install -y chromium-browser
 
 ## Usage
 1. Copy this repository to `/home/pi/DisplayPi` on your Raspberry Pi.
-2. Optionally edit `displaypi.py` to change the URL.
+2. Run `displaypi.py --url local` to display the local page or edit the file to add more options.
 3. Install the systemd service:
 
 ```bash
@@ -32,5 +32,4 @@ sudo systemctl stop displaypi.service
 ```
 
 ## Customization
-Edit `displaypi.py` if you want to change the URL or adjust how Chromium is
-launched.
+Use the `--url` argument to select one of the predefined pages. Edit `displaypi.py` if you want to add more URLs or adjust how Chromium is launched.

--- a/displaypi.py
+++ b/displaypi.py
@@ -5,10 +5,16 @@ This simple script opens a single URL in fullscreen (kiosk) mode using the
 ``chromium-browser`` application that comes with Raspberry Pi OS.
 """
 
+import argparse
 import subprocess
 
-# URL to display
-URL = "https://www.flightradar24.com/simple/"
+
+# URLs that can be displayed. ``flightradar`` is the default page while
+# ``local`` can be used to show a locally hosted web application.
+URLS = {
+    "flightradar": "https://www.flightradar24.com/simple/",
+    "local": "http://localhost:3000",
+}
 
 CHROMIUM_CMD = [
     "chromium-browser",
@@ -24,7 +30,17 @@ def launch_chromium(url: str) -> subprocess.Popen:
 
 
 def main() -> None:
-    proc = launch_chromium(URL)
+    parser = argparse.ArgumentParser(description="Launch Chromium in kiosk mode")
+    parser.add_argument(
+        "--url",
+        choices=URLS.keys(),
+        default="flightradar",
+        help="Which page to display",
+    )
+    args = parser.parse_args()
+
+    url = URLS[args.url]
+    proc = launch_chromium(url)
 
     try:
         proc.wait()


### PR DESCRIPTION
## Summary
- allow choosing a local or flightradar page
- document `--url` option

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568d5dba60832e86684f9929b09f9c