### PR TITLE
Add overlay button for switching tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ sudo systemctl stop displaypi.service
 
 ## Customization
 Use the `--urls` argument to select which predefined pages are opened as tabs. While Chromium is running press **F5** to switch to the next tab and **F6** to go back. Edit `displaypi.py` if you want to add more URLs or adjust how Chromium is launched.
+By default a small button appears in the lower left corner that performs the same action as **Ctrl+Tab** to quickly cycle through the opened tabs. Use the `--no-button` option if you prefer to hide it.


### PR DESCRIPTION
## Summary
- add optional overlay button for Ctrl+Tab navigation
- document new overlay button

## Testing
- `python3 -m py_compile displaypi.py`
- `pip install -r requirements.txt`
- `timeout 5s python3 displaypi.py --urls local --no-button` *(fails: this platform is not supported: failed to acquire X connection)*

------
https://chatgpt.com/codex/tasks/task_e_685700130910832eabd4f089ec96310c