### PR TITLE
Fix overlay tab switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains a small program to display one or more web pages in ful
 - Python 3
 - `chromium-browser`
 - `pynput` Python package (install with `pip install -r requirements.txt`)
+- `xdotool` (install with `sudo apt-get install -y xdotool`)
 
 Install Chromium if it is not already available:
 ```bash
@@ -34,4 +35,4 @@ sudo systemctl stop displaypi.service
 
 ## Customization
 Use the `--urls` argument to select which predefined pages are opened as tabs. While Chromium is running press **F5** to switch to the next tab and **F6** to go back. Edit `displaypi.py` if you want to add more URLs or adjust how Chromium is launched.
-By default a small button appears in the lower left corner that performs the same action as **Ctrl+Tab** to quickly cycle through the opened tabs. Use the `--no-button` option if you prefer to hide it.
+By default a small button appears in the lower left corner that performs the same action as **Ctrl+Tab** to quickly cycle through the opened tabs. The implementation relies on `xdotool` to send the shortcut. Use the `--no-button` option if you prefer to hide it.

--- a/displaypi.py
+++ b/displaypi.py
@@ -56,6 +56,22 @@ def main() -> None:
 
     controller = kb.Controller()
 
+    def send_ctrl_tab(shift: bool = False) -> None:
+        """Simulate Ctrl+Tab (optionally with Shift) using xdotool if available."""
+        cmd = ["xdotool", "key", "--clearmodifiers", "ctrl+"]
+        cmd[-1] += "shift+Tab" if shift else "Tab"
+        try:
+            subprocess.run(cmd, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            controller.press(kb.Key.ctrl)
+            if shift:
+                controller.press(kb.Key.shift)
+            controller.press(kb.Key.tab)
+            controller.release(kb.Key.tab)
+            if shift:
+                controller.release(kb.Key.shift)
+            controller.release(kb.Key.ctrl)
+
     def show_button():
         root = Tk()
         root.overrideredirect(True)
@@ -65,10 +81,7 @@ def main() -> None:
         root.geometry(f"{size}x{size}+0+{screen_height - size}")
 
         def on_click():
-            controller.press(kb.Key.ctrl)
-            controller.press(kb.Key.tab)
-            controller.release(kb.Key.tab)
-            controller.release(kb.Key.ctrl)
+            send_ctrl_tab()
 
         btn = Button(root, text="\u21c6", command=on_click)
         btn.pack(fill="both", expand=True)
@@ -76,17 +89,9 @@ def main() -> None:
 
     def on_press(key):
         if key == kb.Key.f5:
-            controller.press(kb.Key.ctrl)
-            controller.press(kb.Key.tab)
-            controller.release(kb.Key.tab)
-            controller.release(kb.Key.ctrl)
+            send_ctrl_tab()
         elif key == kb.Key.f6:
-            controller.press(kb.Key.ctrl)
-            controller.press(kb.Key.shift)
-            controller.press(kb.Key.tab)
-            controller.release(kb.Key.tab)
-            controller.release(kb.Key.shift)
-            controller.release(kb.Key.ctrl)
+            send_ctrl_tab(shift=True)
 
     listener = kb.Listener(on_press=on_press)
     listener.start()


### PR DESCRIPTION
## Summary
- require `xdotool` in the README
- mention its use in the customization section
- use `xdotool` in `displaypi.py` to send Ctrl+Tab

## Testing
- `python3 -m py_compile displaypi.py`

------
https://chatgpt.com/codex/tasks/task_e_6857012b780c832e81db7f6ce69a759f